### PR TITLE
ci(release): Don't add reference issues to CHANGELOG because of gitmojis

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -129,6 +129,7 @@ jobs:
           excludeTypes: docs, style, refactor, test, ci, dev
           excludeScopes: dev, test, release
           useGitmojis: false
+          includeRefIssues: false
 
       - name: Publish to VS Code Marketplace
         shell: pwsh


### PR DESCRIPTION
See issue reported here:

https://github.com/requarks/changelog-action/issues/68