### PR TITLE
feat: Add configuration settings to disable intellisense hover and completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ bARGE supports functionality expected from modern tables and Azure Resource Grap
 The extension supports the following configuration options in VS Code settings:
 
 - `barge.autoAuthenticate`: Automatically authenticate with Azure on extension activation (default: true)
+- `barge.enableHoverTooltips`: Enable IntelliSense hover tooltips for Azure Resource Graph elements and KQL syntax like keywords, operators, functions, and tables (default: true)
+- `barge.enableCompletions`: Enable IntelliSense completions for Azure Resource Graph elements and KQL syntax like keywords, operators, functions, and tables (default: true)
 
 The default keybindings for executing queries are also possible to change.
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically authenticate to Azure using DefaultAzureCredential on extension activation"
+        },
+        "barge.enableHoverTooltips": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable hover tooltips for KQL syntax"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -167,12 +167,17 @@
         "barge.autoAuthenticate": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically authenticate to Azure using DefaultAzureCredential on extension activation"
+          "description": "Automatically authenticate to Azure using DefaultAzureCredential on extension activation."
         },
         "barge.enableHoverTooltips": {
           "type": "boolean",
           "default": true,
-          "description": "Enable hover tooltips for KQL syntax"
+          "description": "Enable IntelliSense hover tooltips for KQL syntax."
+        },
+        "barge.enableCompletions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable IntelliSense completions for KQL syntax."
         }
       }
     }

--- a/src/kustoLanguageService.ts
+++ b/src/kustoLanguageService.ts
@@ -589,6 +589,14 @@ export class KustoLanguageServiceProvider implements
         position: vscode.Position,
         token: vscode.CancellationToken
     ): Promise<vscode.Hover | null> {
+        // Check if hover is enabled in configuration
+        const config = vscode.workspace.getConfiguration('barge');
+        const enableHoverTooltips = config.get('enableHoverTooltips', true);
+        
+        if (!enableHoverTooltips) {
+            return null;
+        }
+
         // Use enhanced word range detection to handle operators like !contains, mv-apply
         const enhancedWordInfo = this.getEnhancedWordRange(document, position);
         if (!enhancedWordInfo) {

--- a/src/kustoLanguageService.ts
+++ b/src/kustoLanguageService.ts
@@ -68,6 +68,12 @@ export class KustoLanguageServiceProvider implements
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
     ): Promise<vscode.CompletionItem[]> {
+        const config = vscode.workspace.getConfiguration('barge');
+        const enableCompletions = config.get('enableCompletions', true);
+        if (!enableCompletions) {
+            return [];
+        }
+
         const line = document.lineAt(position).text;
         const linePrefix = line.substring(0, position.character);
         const currentWord = this.getCurrentWord(linePrefix);


### PR DESCRIPTION
Introduce configuration options to enable or disable hover tooltips and completions for KQL syntax.

Updates readme to reflect these new settings.

Fixes #95