### PR TITLE
fix(panel): Ensure details button column remains correctly sized for all result table sizes

### DIFF
--- a/media/webview/webview.html
+++ b/media/webview/webview.html
@@ -294,15 +294,19 @@
         }
 
         .detail-button-cell {
-            width: 36px !important;
-            min-width: 36px !important;
-            max-width: 36px !important;
             text-align: center;
             padding: 2px !important;
             vertical-align: middle;
             position: relative;
             /* Prevent focus outline issues */
             outline: none !important;
+        }
+
+        .results-table .detail-button-cell,
+        .results-table th.detail-button-cell {
+            width: 36px !important;
+            min-width: 36px !important;
+            max-width: 36px !important;
         }
 
         .detail-button-cell:focus,
@@ -887,9 +891,16 @@
             cursor: pointer;
             user-select: none;
             z-index: 10;
-            width: 120px;
             min-width: max-content;
             resize: horizontal;
+        }
+
+        .results-table th:not(.detail-button-cell):not(:last-child) {
+            width: 120px;
+        }
+
+        .results-table th:last-child {
+            width: auto;
         }
 
         .results-table th:hover {


### PR DESCRIPTION
Fixes a visual bug caused as a side-effect of #154.

Details button cells are now fixed size again. The width of the last column of the table is set to "auto", to fill the rest of the table if necessary.