### PR TITLE
chore: Fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,5 +1,7 @@
 name: Build, Test, and Release (if tag)
 
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/PalmEmanuel/bARGE/security/code-scanning/7](https://github.com/PalmEmanuel/bARGE/security/code-scanning/7)

To fix this issue, the workflow should specify a `permissions` block with limited scope, ideally at the root level to cover all jobs that do not require elevated access, or per job if jobs differ in needs. Since only the `release` job needs elevated permissions (already explicitly declared), the best practice is to add a root-level `permissions:` block with `contents: read`, ensuring `build` and `test` jobs receive minimal permissions. These jobs require only `actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact`, none of which require write-level repository access.

**Required change:**  
Add the following at the top level (after `name:` or `on:` block, before `jobs:`):

```yaml
permissions:
  contents: read
```

This will apply to all jobs except those (like `release`) that have an explicit override.

**Files/regions/lines to change:**  
In `.github/workflows/build-test-release.yml`, insert:

```yaml
permissions:
  contents: read
```

just after the `name:` and before/in/after the `on:` block (either position is supported and equivalent).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
