### PR TITLE
feat: Queries can now be run in new tabs to retain results

### DIFF
--- a/media/icons/target-dark.svg
+++ b/media/icons/target-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5" fill="#007ACC"/>
+</svg>

--- a/media/icons/target-light.svg
+++ b/media/icons/target-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5" fill="#005FB8"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -47,8 +47,24 @@
         "category": "bARGE"
       },
       {
+        "command": "barge.setScope",
+        "title": "Set Query Scope",
+        "category": "bARGE"
+      },
+      {
+        "command": "barge.authenticate",
+        "title": "Sign In",
+        "category": "bARGE"
+      },
+      {
         "command": "barge.runQueryFromFile",
         "title": "Run Query from File",
+        "category": "bARGE",
+        "icon": "$(play)"
+      },
+      {
+        "command": "barge.runQueryFromFileNewTab",
+        "title": "Run Query from File (New Tab)",
         "category": "bARGE",
         "icon": "$(play)"
       },
@@ -59,14 +75,10 @@
         "icon": "$(debug-line-by-line)"
       },
       {
-        "command": "barge.setScope",
-        "title": "Set Query Scope",
-        "category": "bARGE"
-      },
-      {
-        "command": "barge.authenticate",
-        "title": "Sign In",
-        "category": "bARGE"
+        "command": "barge.runQueryFromSelectionNewTab",
+        "title": "Run Selected Query (New Tab)",
+        "category": "bARGE",
+        "icon": "$(debug-line-by-line)"
       }
     ],
     "menus": {
@@ -102,10 +114,22 @@
           "group": "barge@1"
         },
         {
+          "command": "barge.runQueryFromFileNewTab",
+          "title": "bARGE: Run Query from File (New Tab)",
+          "when": "editorLangId == kql || resourceExtname == .kql",
+          "group": "barge@2"
+        },
+        {
           "command": "barge.runQueryFromSelection",
           "title": "bARGE: Run Selected Query",
           "when": "(editorHasSelection || barge.hasImplicitQuery) && (editorLangId == kql || resourceExtname == .kql || editorLangId == powershell || resourceExtname == .ps1 || editorLangId == plaintext)",
-          "group": "barge@2"
+          "group": "barge@3"
+        },
+        {
+          "command": "barge.runQueryFromSelectionNewTab",
+          "title": "bARGE: Run Selected Query (New Tab)",
+          "when": "(editorHasSelection || barge.hasImplicitQuery) && (editorLangId == kql || resourceExtname == .kql || editorLangId == powershell || resourceExtname == .ps1 || editorLangId == plaintext)",
+          "group": "barge@4"
         }
       ],
       "explorer/context": [
@@ -138,6 +162,18 @@
       {
         "command": "barge.runQueryFromFile",
         "key": "f5",
+        "when": "editorTextFocus && (editorLangId == kql || resourceExtname == .kql)"
+      },
+      {
+        "command": "barge.runQueryFromSelectionNewTab",
+        "key": "ctrl+f8",
+        "mac": "cmd+f8",
+        "when": "editorTextFocus && (editorHasSelection || barge.hasImplicitQuery) && (editorLangId == kql || resourceExtname == .kql)"
+      },
+      {
+        "command": "barge.runQueryFromFileNewTab",
+        "key": "ctrl+f5",
+        "mac": "cmd+f5",
         "when": "editorTextFocus && (editorLangId == kql || resourceExtname == .kql)"
       }
     ],

--- a/src/bargePanel.ts
+++ b/src/bargePanel.ts
@@ -6,25 +6,114 @@ import { AzureService } from './azure/azureService';
 import { WebviewMessage, QueryResponse, ResolveGuidRequest, ResolveGuidResponse, IdentityInfo } from './types';
 
 export class BargePanel {
-    public static currentPanel: BargePanel | undefined;
+    /** All live panels. */
+    private static _panels: Set<BargePanel> = new Set();
+    /** Per-file target panel — the one that "Run Query" writes to. */
+    private static _targetPanels: Map<string, BargePanel> = new Map();
+    /** File key of the currently-active editor (undefined when not in a supported file). */
+    private static _activeFileKey: string | undefined;
+    /** Monotonically increasing counter for stable creation ordering. */
+    private static _globalCreationCounter = 0;
     public static readonly viewType = 'bargeResults';
 
     private readonly _panel: vscode.WebviewPanel;
     private readonly _azureService: AzureService;
     private readonly _extensionUri: vscode.Uri;
+    private _sourceFileKey: string;
+    private readonly _creationOrder: number;
     private _disposables: vscode.Disposable[] = [];
 
-    public static createOrShow(extensionUri: vscode.Uri, azureService: AzureService) {
-        if (BargePanel.currentPanel) {
-            // Don't force repositioning - just reveal where it currently is
-            BargePanel.currentPanel._panel.reveal();
-            return;
+    // ── public static API ──────────────────────────────────────────────
+
+    /**
+     * Derive a panel-tracking key from a file name.
+     * Returns the basename (e.g. "storage.kql") or "untitled" for no-file contexts.
+     */
+    public static getFileKey(fileName?: string): string {
+        if (!fileName || fileName === '' || fileName.startsWith('Untitled')) {
+            return 'untitled';
+        }
+        return path.basename(fileName);
+    }
+
+    /**
+     * Get or create the target panel for a given file.
+     * If a target already exists it is revealed; otherwise a new panel is created.
+     */
+    public static getOrCreateForFile(extensionUri: vscode.Uri, azureService: AzureService, fileKey: string): BargePanel {
+        const existing = BargePanel._targetPanels.get(fileKey);
+        if (existing) {
+            existing._panel.reveal();
+            return existing;
+        }
+        return BargePanel._createPanel(extensionUri, azureService, fileKey);
+    }
+
+    /**
+     * Create a new panel for a file and promote it to the target for that file.
+     */
+    public static createNewForFile(extensionUri: vscode.Uri, azureService: AzureService, fileKey: string): BargePanel {
+        return BargePanel._createPanel(extensionUri, azureService, fileKey);
+    }
+
+    /**
+     * Update the active file key (called when the active editor changes).
+     * Hides/shows the focus indicator on panel titles accordingly.
+     */
+    public static setActiveFileKey(fileKey: string | undefined): void {
+        if (BargePanel._activeFileKey === fileKey) { return; }
+        BargePanel._activeFileKey = fileKey;
+        BargePanel._updateAllTitles();
+    }
+
+    /**
+     * Return the current target panel for a file, if any.
+     */
+    public static getTargetForFile(fileKey: string): BargePanel | undefined {
+        return BargePanel._targetPanels.get(fileKey);
+    }
+
+    /**
+     * Re-key all panels associated with `oldKey` to `newKey`.
+     * Called when a source file is renamed.
+     */
+    public static handleFileRename(oldKey: string, newKey: string): void {
+        if (oldKey === newKey) { return; }
+
+        // Move target mapping
+        const target = BargePanel._targetPanels.get(oldKey);
+        if (target) {
+            BargePanel._targetPanels.delete(oldKey);
+            // If the new key already has a target, keep the existing one.
+            // Otherwise promote the old target.
+            if (!BargePanel._targetPanels.has(newKey)) {
+                BargePanel._targetPanels.set(newKey, target);
+            }
         }
 
-        // Create panel in bottom area by default
+        // Update every panel's source file key
+        for (const panel of BargePanel._panels) {
+            if (panel._sourceFileKey === oldKey) {
+                panel._sourceFileKey = newKey;
+            }
+        }
+
+        // Update active file key if it matched the old name
+        if (BargePanel._activeFileKey === oldKey) {
+            BargePanel._activeFileKey = newKey;
+        }
+
+        BargePanel._updateAllTitles();
+    }
+
+    // ── internal helpers ───────────────────────────────────────────────
+
+    private static _createPanel(extensionUri: vscode.Uri, azureService: AzureService, fileKey: string): BargePanel {
+        BargePanel._globalCreationCounter++;
+
         const panel = vscode.window.createWebviewPanel(
             BargePanel.viewType,
-            'bARGE - boosted Azure Resource Graph Explorer',
+            'bARGE', // placeholder — _updateAllTitles sets the real title
             { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
             {
                 enableScripts: true,
@@ -36,21 +125,100 @@ export class BargePanel {
             }
         );
 
-        BargePanel.currentPanel = new BargePanel(panel, extensionUri, azureService);
+        const bargePanel = new BargePanel(panel, extensionUri, azureService, fileKey, BargePanel._globalCreationCounter);
+        BargePanel._panels.add(bargePanel);
+        BargePanel._targetPanels.set(fileKey, bargePanel);
+        BargePanel._updateAllTitles();
 
         // Move to bottom panel after creation
         vscode.commands.executeCommand('workbench.action.moveEditorToBelowGroup');
+
+        return bargePanel;
     }
 
-    private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, azureService: AzureService) {
+    /**
+     * Recompute every panel's title and icon.
+     *
+     * Title format:  bARGE[: filename][ (N)]
+     *   : filename   — shown for file-associated panels (omitted for "untitled")
+     *   (N)          — shown when more than one panel exists for the same file
+     * Icon:          filled blue circle on the target panel whose file matches the active editor
+     */
+    private static _updateAllTitles(): void {
+        // Group panels by file key, sorted by creation order
+        const groups = new Map<string, BargePanel[]>();
+        for (const panel of BargePanel._panels) {
+            const key = panel._sourceFileKey;
+            if (!groups.has(key)) { groups.set(key, []); }
+            groups.get(key)!.push(panel);
+        }
+
+        for (const [fileKey, panels] of groups) {
+            panels.sort((a, b) => a._creationOrder - b._creationOrder);
+
+            const target = BargePanel._targetPanels.get(fileKey);
+            const isActiveFile = BargePanel._activeFileKey === fileKey;
+
+            for (let i = 0; i < panels.length; i++) {
+                const p = panels[i];
+                const isTarget = p === target && isActiveFile;
+
+                const baseName = fileKey === 'untitled'
+                    ? 'bARGE'
+                    : `bARGE: ${fileKey}`;
+                const suffix = panels.length > 1 ? ` (${i + 1})` : '';
+
+                p._panel.title = `${baseName}${suffix}`;
+
+                if (isTarget) {
+                    p._panel.iconPath = {
+                        light: vscode.Uri.joinPath(p._extensionUri, 'media', 'icons', 'target-light.svg'),
+                        dark: vscode.Uri.joinPath(p._extensionUri, 'media', 'icons', 'target-dark.svg')
+                    };
+                } else {
+                    p._panel.iconPath = undefined;
+                }
+            }
+        }
+    }
+
+    // ── instance ───────────────────────────────────────────────────────
+
+    private constructor(
+        panel: vscode.WebviewPanel,
+        extensionUri: vscode.Uri,
+        azureService: AzureService,
+        sourceFileKey: string,
+        creationOrder: number
+    ) {
         this._panel = panel;
         this._azureService = azureService;
         this._extensionUri = extensionUri;
+        this._sourceFileKey = sourceFileKey;
+        this._creationOrder = creationOrder;
         this._update();
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
         this._panel.webview.onDidReceiveMessage(
             (message: WebviewMessage) => {
                 this._handleMessage(message);
+            },
+            null,
+            this._disposables
+        );
+        // When a bARGE panel gains focus, promote it to target for its file.
+        // Only update the active file key if the panel belongs to the already-active
+        // file — otherwise clicking a panel for another file would steal the indicator
+        // from the file the user is actually editing.
+        this._panel.onDidChangeViewState(
+            (e) => {
+                if (e.webviewPanel.active) {
+                    BargePanel._targetPanels.set(this._sourceFileKey, this);
+
+                    if (BargePanel._activeFileKey === this._sourceFileKey || BargePanel._activeFileKey === undefined) {
+                        BargePanel._activeFileKey = this._sourceFileKey;
+                    }
+                    BargePanel._updateAllTitles();
+                }
             },
             null,
             this._disposables
@@ -297,7 +465,27 @@ export class BargePanel {
     }
 
     public dispose() {
-        BargePanel.currentPanel = undefined;
+        BargePanel._panels.delete(this);
+
+        // If this was the target for its file, promote the most recently created survivor
+        if (BargePanel._targetPanels.get(this._sourceFileKey) === this) {
+            BargePanel._targetPanels.delete(this._sourceFileKey);
+
+            let fallback: BargePanel | undefined;
+            for (const p of BargePanel._panels) {
+                if (p._sourceFileKey === this._sourceFileKey) {
+                    if (!fallback || p._creationOrder > fallback._creationOrder) {
+                        fallback = p;
+                    }
+                }
+            }
+            if (fallback) {
+                BargePanel._targetPanels.set(this._sourceFileKey, fallback);
+            }
+        }
+
+        BargePanel._updateAllTitles();
+
         this._panel.dispose();
         while (this._disposables.length) {
             const x = this._disposables.pop();

--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -30,13 +30,19 @@ export class BargeCodeLensProvider implements vscode.CodeLensProvider {
                 continue;
             }
 
-            const lens = new vscode.CodeLens(block, {
-                title: '► Run Query',
+            const runLens = new vscode.CodeLens(block, {
+                title: '► Run',
                 command: 'barge.runQueryFromCodeLens',
                 arguments: [queryText, document.fileName],
                 tooltip: 'Run this query in bARGE'
             });
-            lenses.push(lens);
+            const newTabLens = new vscode.CodeLens(block, {
+                title: '► Run (New Tab)',
+                command: 'barge.runQueryFromCodeLensNewTab',
+                arguments: [queryText, document.fileName],
+                tooltip: 'Run this query in a new bARGE tab'
+            });
+            lenses.push(runLens, newTabLens);
         }
 
         return lenses;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register command to open results panel
 	const openResultsCommand = vscode.commands.registerCommand('barge.openResults', () => {
-		BargePanel.createOrShow(context.extensionUri, azureService);
+		const fileKey = getActiveFileKey();
+		BargePanel.getOrCreateForFile(context.extensionUri, azureService, fileKey);
 	});
 
 	// Register command to run query from current file
@@ -147,25 +148,107 @@ export function activate(context: vscode.ExtensionContext) {
 		await runQueryInPanel(queryText, 'selection', fileName);
 	});
 
-	// Helper function to run query in panel
+	// Register CodeLens command to run a query in a new tab
+	const runFromCodeLensNewTabCommand = vscode.commands.registerCommand('barge.runQueryFromCodeLensNewTab', async (queryText: string, fileName: string) => {
+		await runQueryInNewTab(queryText, 'selection', fileName);
+	});
+
+	// Register command to run query from file in a new tab
+	const runQueryFromFileNewTabCommand = vscode.commands.registerCommand('barge.runQueryFromFileNewTab', async (uri?: vscode.Uri) => {
+		let document: vscode.TextDocument;
+		let fileName: string;
+
+		if (uri) {
+			try {
+				document = await vscode.workspace.openTextDocument(uri);
+				fileName = uri.fsPath;
+			} catch (error) {
+				const errorMsg = (error && typeof error === 'object' && 'message' in error) ? (error as Error).message : '';
+				vscode.window.showErrorMessage(`Failed to open file.${errorMsg ? ' Error: ' + errorMsg : ''}`);
+				return;
+			}
+		} else {
+			const activeEditor = vscode.window.activeTextEditor;
+			if (!activeEditor) {
+				vscode.window.showErrorMessage('No active file found');
+				return;
+			}
+			document = activeEditor.document;
+			fileName = document.fileName;
+		}
+
+		const query = document.getText().trim();
+		if (!query) {
+			vscode.window.showErrorMessage('File is empty or contains no query');
+			return;
+		}
+
+		await runQueryInNewTab(query, 'file', fileName);
+	});
+
+	// Register command to run query from selection in a new tab
+	const runQueryFromSelectionNewTabCommand = vscode.commands.registerCommand('barge.runQueryFromSelectionNewTab', async () => {
+		const activeEditor = vscode.window.activeTextEditor;
+		if (!activeEditor) {
+			vscode.window.showErrorMessage('No active file found');
+			return;
+		}
+
+		const selection = activeEditor.selection;
+		let selectedText = activeEditor.document.getText(selection);
+		let queryText = selectedText.trim();
+
+		if (!selectedText) {
+			const implicitRange = getImplicitQueryRange(activeEditor.document, selection.active);
+			if (!implicitRange) {
+				vscode.window.showErrorMessage('No text selected and no implicit query selection found');
+				return;
+			}
+			queryText = activeEditor.document.getText(implicitRange).trim();
+		}
+
+		if (!queryText) {
+			vscode.window.showErrorMessage('No text selected and no implicit query selection found');
+			return;
+		}
+
+		await runQueryInNewTab(queryText, 'selection', activeEditor.document.fileName);
+	});
+
+	// Derive the file key for panel routing from the active editor
+	function getActiveFileKey(): string {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) { return BargePanel.getFileKey(); }
+		return BargePanel.getFileKey(editor.document.fileName);
+	}
+
+	// Helper function to run query in the target panel for its source file
 	async function runQueryInPanel(query: string, source: 'file' | 'selection', fileName?: string) {
 		try {
-			// Ensure authentication
 			if (!azureService.isAuthenticated()) {
 				const authResult = await azureService.authenticate();
-				if (!authResult) {
-					return;
-				}
+				if (!authResult) { return; }
 			}
 
-			// Create or show the panel
-			BargePanel.createOrShow(context.extensionUri, azureService);
-			
-			// Run the query
-			if (BargePanel.currentPanel) {
-				await BargePanel.currentPanel.runQuery(query, source, fileName);
+			const fileKey = BargePanel.getFileKey(fileName);
+			const panel = BargePanel.getOrCreateForFile(context.extensionUri, azureService, fileKey);
+			await panel.runQuery(query, source, fileName);
+		} catch (error) {
+			vscode.window.showErrorMessage(`Query execution failed: ${error}`);
+		}
+	}
+
+	// Helper function to run query in a brand-new tab (promoted to target)
+	async function runQueryInNewTab(query: string, source: 'file' | 'selection', fileName?: string) {
+		try {
+			if (!azureService.isAuthenticated()) {
+				const authResult = await azureService.authenticate();
+				if (!authResult) { return; }
 			}
-			
+
+			const fileKey = BargePanel.getFileKey(fileName);
+			const panel = BargePanel.createNewForFile(context.extensionUri, azureService, fileKey);
+			await panel.runQuery(query, source, fileName);
 		} catch (error) {
 			vscode.window.showErrorMessage(`Query execution failed: ${error}`);
 		}
@@ -179,6 +262,9 @@ export function activate(context: vscode.ExtensionContext) {
 		setScopeCommand,
 		authenticateCommand,
 		runFromCodeLensCommand,
+		runFromCodeLensNewTabCommand,
+		runQueryFromFileNewTabCommand,
+		runQueryFromSelectionNewTabCommand,
 		statusBar // Add status bar for proper cleanup
 	);
 
@@ -203,6 +289,36 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		})
 	);
+
+	// Track the active editor so panel titles show the focus indicator.
+	// When editor is undefined a non-editor view (e.g. a bARGE webview) has focus;
+	// the panel's own onDidChangeViewState handles that case, so we leave the key alone.
+	function updateActiveFileKeyFromEditor(editor?: vscode.TextEditor): void {
+		if (!editor) { return; }
+
+		const langId = editor.document.languageId;
+		const isSupported = langId === 'kql'
+			|| editor.document.fileName.endsWith('.kql')
+			|| langId === 'powershell'
+			|| editor.document.fileName.endsWith('.ps1')
+			|| langId === 'plaintext';
+		BargePanel.setActiveFileKey(isSupported ? BargePanel.getFileKey(editor.document.fileName) : undefined);
+	}
+
+	// Set initial state and subscribe to editor changes
+	updateActiveFileKeyFromEditor(vscode.window.activeTextEditor);
+	const activeEditorTracker = vscode.window.onDidChangeActiveTextEditor(updateActiveFileKeyFromEditor);
+	context.subscriptions.push(activeEditorTracker);
+
+	// Re-key panels when source files are renamed
+	const renameTracker = vscode.workspace.onDidRenameFiles(e => {
+		for (const { oldUri, newUri } of e.files) {
+			const oldKey = BargePanel.getFileKey(oldUri.fsPath);
+			const newKey = BargePanel.getFileKey(newUri.fsPath);
+			BargePanel.handleFileRename(oldKey, newKey);
+		}
+	});
+	context.subscriptions.push(renameTracker);
 
 	// Slight, subtle highlight used to indicate the implicit query under cursor.
 	let implicitQueryDecoration: vscode.TextEditorDecorationType | undefined;


### PR DESCRIPTION
CodeLens buttons, right click actions and menu options all now support running queries in a new tab.

Running a query will always run in the tab indicated by a blue circle, which is tied to the file that the query was run in, and the most recently interacted-with tab.

- Closes #200 